### PR TITLE
updates the `range_date` crate to version 0.2.1 and enhances its documentation to better

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "range_date"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
-description = "A Rust crate for date range handling with support for years, quarters, months, and days."
+description = "A powerful Rust crate for handling date periods with embedded data and comprehensive date range operations."
 license = "MIT"
 repository = "https://github.com/GuoMonth/range_date"
 homepage = "https://github.com/GuoMonth/range_date"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-range_date = "0.2.0"
+range_date = "0.2.1"
 ```
 
 ## Usage Examples

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ A powerful Rust crate for handling date periods with embedded data and comprehen
 - 🔄 **Type Conversion**: String parsing and serialization support with validation
 - 📅 **Date Range Operations**: Calculate first/last days, check date containment
 - 🎯 **Date Conversion**: Convert NaiveDate to any period type
+- 🔀 **Advanced Period Operations**: Navigate between periods (succ/pred), decompose into sub-periods, aggregate to parent periods
+- 📊 **Range Generation**: Generate all periods between two dates for comprehensive date range analysis
+- 📚 **Comprehensive Documentation**: 26+ doc tests with practical examples for all public methods
 - ⚡ **High Performance**: Built on top of the efficient `chrono` library
 - 🛡️ **Type Safety**: Complete validation with proper error handling
 - 🧪 **Leap Year Support**: Accurate leap year detection and day validation


### PR DESCRIPTION
This pull request updates the `range_date` crate to version 0.2.1 and enhances its documentation to better reflect new features and improvements. The most important changes include updating the version number, expanding the feature list in the README, and improving the crate description for clarity.

Version and Documentation Updates:

* Bumped the crate version from `0.2.0` to `0.2.1` in both `Cargo.toml` and the installation example in `README.md`, ensuring consistency and reflecting the latest release. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R29)
* Expanded the feature list in the `README.md` to highlight advanced period operations, range generation, and comprehensive documentation with practical examples.
* Updated the crate description in `Cargo.toml` to better communicate its capabilities and improvements in date period handling.