### PR TITLE
Guosheng/feat 1021

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,13 @@ let back_to_q1 = q2.pred().unwrap(); // Previous: 2024Q1
 
 // Period decomposition - Break down into sub-periods
 let year_2024 = DatePeriod::year(2024);
-let quarters_in_year = year_2024.decompose().unwrap();
+let quarters_in_year = year_2024.decompose();
 assert_eq!(quarters_in_year.len(), 4); // 4 quarters in a year
 
 // Period aggregation - Get parent period
 let month = DatePeriod::month(2024, 5).unwrap();
-let quarter = month.aggregate().unwrap();
-assert_eq!(quarter, Some(DatePeriod::quarter(2024, 2).unwrap()));
+let quarter = month.aggregate();
+assert_eq!(quarter, DatePeriod::quarter(2024, 2).unwrap());
 ```
 
 ### Period Information Queries **[NEW]**


### PR DESCRIPTION
This pull request refactors the `DatePeriod::decompose` and `DatePeriod::aggregate` methods to simplify their APIs and usage throughout the codebase. The main improvement is the removal of unnecessary `Result` and `Option` wrappers, making these methods return their values directly. This leads to cleaner and more intuitive code for period decomposition and aggregation.

### API Simplification

* Refactored the `DatePeriod::decompose` method to return a plain `Vec<DatePeriod>` instead of a `Result`, removing the need for `.unwrap()` in both implementation and usage examples. [[1]](diffhunk://#diff-1c77953b894d418d7291ea1ea1c330b6090744141b846b35c292bef02e018d84L681-R687) [[2]](diffhunk://#diff-1c77953b894d418d7291ea1ea1c330b6090744141b846b35c292bef02e018d84L717-R717)
* Refactored the `DatePeriod::aggregate` method to return a direct parent `DatePeriod` (or itself for `Year`) instead of an `Option` wrapped in a `Result`, simplifying both implementation and usage.

### Documentation and Example Updates

* Updated documentation and code examples in `README.md` and doc comments to reflect the new method signatures and usage patterns, removing `.unwrap()` and handling direct values. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L139-R145) [[2]](diffhunk://#diff-1c77953b894d418d7291ea1ea1c330b6090744141b846b35c292bef02e018d84L728-R760)

### Test Adjustments

* Modified unit tests to match the new APIs, removing `.unwrap()` and updating assertions to directly compare returned values.