### PR TITLE
Bump version to 0.2.3 in Cargo.toml and update README for dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "range_date"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "A powerful Rust crate for handling date periods with embedded data and comprehensive date range operations."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-range_date = "0.2.1"
+range_date = "0.2.3"
 ```
 
 ## Usage Examples


### PR DESCRIPTION
This pull request updates the crate version for `range_date` to `0.2.3` in both the `Cargo.toml` file and the installation instructions in the `README.md`. This ensures that users and dependencies reference the latest release. 

Version update:

* Bumped the crate version from `0.2.2` to `0.2.3` in `Cargo.toml`.

Documentation update:

* Updated the `README.md` installation example to use `range_date = "0.2.3"` instead of the previous version.