### PR TITLE
ci: 升级 GitHub Actions 版本并对齐主流实践

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,23 +7,32 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
 
 jobs:
   build:
-    name: Build & Test
+    name: Build & Test (${{ matrix.rust }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust: [stable, beta, nightly]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -37,7 +46,10 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run Clippy lints
-        run: cargo clippy -- -D clippy::expect_used -D clippy::panic -D clippy::unwrap_used -D warnings
+        run: cargo clippy --all-features -- -D clippy::expect_used -D clippy::panic -D clippy::unwrap_used -D warnings
+
+      - name: Run Clippy lints (tests)
+        run: cargo clippy --tests --all-features -- -D warnings
 
       - name: Build project
         run: cargo build --all --verbose
@@ -47,7 +59,9 @@ jobs:
 
       - name: Install tarpaulin
         if: matrix.rust == 'stable'
-        run: cargo install cargo-tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
 
       - name: Generate coverage report
         if: matrix.rust == 'stable'
@@ -55,9 +69,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.rust == 'stable'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage/cobertura.xml
+          files: ./coverage/cobertura.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
@@ -67,18 +81,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
 
       - name: Run security audit
         run: cargo audit
@@ -91,12 +105,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## 概要

对 `.github/workflows/rust.yml` 做一次常规维护，升级第三方 Action 到最新稳定版，并按 2026 年主流 Rust CI 实践做若干优化。

## 变更详情

### Action 版本升级
| Action | 旧 | 新 |
| --- | --- | --- |
| `actions/checkout` | v4 | v5 |
| `codecov/codecov-action` | v4 | v5（并把已弃用的 `file:` 参数改为 `files:`） |
| `dtolnay/rust-toolchain` | `@v1` | `@master`（矩阵任务）/ `@stable`（单一工具链任务），与官方 README 推荐写法对齐 |
| `Swatinem/rust-cache` | v2 | v2（保持不变，当前主版本） |

### 安装方式优化
- 用 [`taiki-e/install-action@v2`](https://github.com/taiki-e/install-action) 替代 `cargo install cargo-tarpaulin` / `cargo install cargo-audit`，直接下载预编译二进制，CI 单次耗时显著下降（通常从数分钟降至数秒）。

### 工作流加固
- 顶层 `permissions: contents: read`：启用最小权限原则。
- `concurrency` + `cancel-in-progress`：PR 推新 commit 自动取消进行中的旧运行，节省分钟数。
- `env.RUSTFLAGS: -D warnings`：让编译期警告也成为硬性错误。
- 矩阵 `fail-fast: false`：一个工具链失败不会中断其它工具链。

### Clippy 拆分
将原本的一步 clippy 拆为两步：
- 生产代码：保留 `-D clippy::expect_used -D clippy::panic -D clippy::unwrap_used -D warnings`。
- 测

## 本地验证
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-features -- -D clippy::expect_used -D clippy::panic -D clippy::unwrap_used -D warnings` ✅
- `cargo clippy --tests --all-features -- -D warnings` ✅
- `cargo build` / `cargo test` ✅