### PR TITLE
chore: bump version to 0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "range_date"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "A powerful Rust crate for handling date periods with embedded data and comprehensive date range operations."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Rust crate for handling date periods (year / quarter / month / day) with valid
 
 ```toml
 [dependencies]
-range_date = "0.2.3"
+range_date = "0.2.4"
 ```
 
 ## Period Types


### PR DESCRIPTION
## 概要

发布新版本 `0.2.4`，包含自 `0.2.3` 以来合并的改进。

## 变更
- `Cargo.toml`: `version = "0.2.3"` → `"0.2.4"`
- `README.md`: `range_date = "0.2.3"` → `"0.2.4"`

## 自 0.2.3 起的主要变更
- **deps**: 升级 anyhow / chrono / serde / serde_json 到最新稳定版
- **clippy/docs**: 修复 clippy 告警；为所有返回 `Result` 的公开 API 补齐 `# Errors` 小节；反引号包装类型名
- **ci**: 升级 GitHub Actions、接入 Dependabot、加固 release 环境（required reviewer + tag 策略）、新增 `cargo doc` / weekly security audit 等
- **docs**: 精简 README（241 → 91 行）

## 合并后
将基于最新 main 打 `v0.2.4` tag，自动触发 CI → review gate → 发布到 crates.io。